### PR TITLE
Fix distorted thumbnail

### DIFF
--- a/assets/tvs/multitv/css/multitv.css
+++ b/assets/tvs/multitv/css/multitv.css
@@ -60,8 +60,8 @@
 
 .multitv .list li.element .DatePicker { padding: 3px 3px 3px 24px }
 
-.multitv .list li.element .mtvThumb { float: right; margin-right: 12px; width: 96px }
-.multitv .list li.element .mtvThumb img { width: auto; height: 96px; float: right }
+.multitv .list li.element .mtvThumb { float: right; margin-right: 12px; }
+.multitv .list li.element .mtvThumb img { width: auto; max-height: 96px; min-height:50px; float: right }
 .multitv .list li.element .thumb { border: 1px solid #ccc !important }
 
 .multitv .list li.element .mtvThumb.inline { float: left; margin-right: 5px; width: 26px }


### PR DESCRIPTION
Hi there,
with this fix thumbnails are no longer displayed as a distorted square. Now they are displayed proportionally with a min-height of 50px and a max-height of 96px. The width depends on the image.