### PR TITLE
Update multitv.class.php

### DIFF
--- a/assets/tvs/multitv/includes/multitv.class.php
+++ b/assets/tvs/multitv/includes/multitv.class.php
@@ -1164,6 +1164,9 @@ class multiTV
                 ],
             ], $value));
 
+            if($value == false) continue;
+            
+
             if (!$params['toJson']) {
                 if ($display == 1) {
                     $classes[] = $params['lastClass'];


### PR DESCRIPTION
Если строки обрабатываются prepare-сниппетом, то в отличие от DocLister-а, return false из prepare-сниппета не исключит строку из вывода, и она все равно будет отрендерена в соответствии с шаблоном rowTpl, но  с пустыми плейсхолдерами. (В результате в выводе появляются лишние включения "пустых" экземпляров rowTpl). Добавление данной проверки результата обработки prepare-сниппетом  решает данную проблему.