### PR TITLE
Fixed variable not being assigned in a branch of the code

### DIFF
--- a/assets/tvs/multitv/includes/multitv.class.php
+++ b/assets/tvs/multitv/includes/multitv.class.php
@@ -1088,6 +1088,8 @@ class multiTV
         $params['rowTpl'] = str_replace(array_keys($maskedTags), array_values($maskedTags), $params['rowTpl']);
         if(is_array($tvOutput)){ 
             $countOutput = count($tvOutput);
+        } else {
+            $countOutput = 0;
         }
         $firstEmpty = true;
         if ($countOutput) {


### PR DESCRIPTION
I added fixed value to `$countOutput` if `$tvOutput` is not array. If the variable does not exists, then PHP8 raises Warning, as opposed to Notice in previous versions, see https://www.php.net/manual/en/migration80.incompatible.php